### PR TITLE
Use Citrus framework for email-listener integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ target/
 data/
 .attach_*
 derby.log
+test-output
+.DS_Store
+.idea
+*.iml
+*.ipr
+*.iws
+.metadata

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<saxon.bundle.version>9.5.1-1_1</saxon.bundle.version>
 		<commons-lang-version>2.6</commons-lang-version>
 		<postgresql-version>8.4-702.jdbc4</postgresql-version>
-	    <spring-jdbc-version>3.2.8.RELEASE</spring-jdbc-version>
+	  <spring-jdbc-version>3.2.8.RELEASE</spring-jdbc-version>
 
 		<!-- Logging Properties -->
 		<slf4j-version>1.6.6</slf4j-version>
@@ -82,6 +82,7 @@
 		<ftpserver-version>1.0.6</ftpserver-version>
 		<sshd-version>0.10.0</sshd-version>
 		<greenmail-version>1.4.0</greenmail-version>
+		<citrus-version>2.5.1</citrus-version>
 
 		<!-- Plugin Versions -->
 		<compiler-plugin-version>3.1</compiler-plugin-version>

--- a/service.polling.emaillistener/pom.xml
+++ b/service.polling.emaillistener/pom.xml
@@ -26,7 +26,7 @@
 			<artifactId>entities.travel</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<!-- Fuse Dependencies -->
 		<dependency>
 			<groupId>org.apache.camel</groupId>
@@ -56,7 +56,7 @@
 			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-mail</artifactId>
 		</dependency>
-		
+
 		<!-- the ActiveMQ client with connection pooling -->
 
 		<dependency>
@@ -116,7 +116,99 @@
 			<version>${greenmail-version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.consol.citrus</groupId>
+			<artifactId>citrus-core</artifactId>
+			<version>${citrus-version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.consol.citrus</groupId>
+			<artifactId>citrus-java-dsl</artifactId>
+			<version>${citrus-version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.consol.citrus</groupId>
+			<artifactId>citrus-jms</artifactId>
+			<version>${citrus-version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.consol.citrus</groupId>
+			<artifactId>citrus-mail</artifactId>
+			<version>${citrus-version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.consol.citrus</groupId>
+			<artifactId>citrus-camel</artifactId>
+			<version>${citrus-version}</version>
+			<scope>test</scope>
+		</dependency>
 
+		<!-- Spring dependencies -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-core</artifactId>
+			<version>4.2.3.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-beans</artifactId>
+			<version>4.2.3.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>4.2.3.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jms</artifactId>
+			<version>4.2.3.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<version>4.2.3.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-aop</artifactId>
+			<version>4.2.3.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+			<version>4.2.3.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-tx</artifactId>
+			<version>4.2.3.RELEASE</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm</artifactId>
+			<version>5.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.ow2.asm</groupId>
+			<artifactId>asm-commons</artifactId>
+			<version>5.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/service.polling.emaillistener/src/main/resources/OSGI-INF/blueprint/blueprint-polling-email.xml
+++ b/service.polling.emaillistener/src/main/resources/OSGI-INF/blueprint/blueprint-polling-email.xml
@@ -96,6 +96,7 @@
 					<to uri="bean:flightSegmentRecordCsvHandler?method=fromCSV" />
 					<marshal ref="jaxb" />
 					<log message="Email: FLIGHT SEGMENT RECORD XML --- ${body}" />
+					<convertBodyTo type="java.lang.String"/>
 					<to uri="activemq:{{outbound.jms.dest}}" />
 				</split>
 			</split>

--- a/service.polling.emaillistener/src/test/java/org/jboss/fuse/service/polling/emaillistener/EmailListenerTest.java
+++ b/service.polling.emaillistener/src/test/java/org/jboss/fuse/service/polling/emaillistener/EmailListenerTest.java
@@ -1,74 +1,44 @@
 package org.jboss.fuse.service.polling.emaillistener;
 
-import java.io.File;
-import java.net.URI;
-import java.util.Calendar;
-import java.util.List;
-
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
-import javax.activation.FileDataSource;
-import javax.mail.Message;
-import javax.mail.Multipart;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
-
-import org.apache.activemq.broker.BrokerService;
-import org.apache.activemq.broker.TransportConnector;
-import org.apache.camel.Route;
-import org.apache.camel.ServiceStatus;
-import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.icegreen.greenmail.user.GreenMailUser;
+import com.consol.citrus.Citrus;
+import com.consol.citrus.container.IteratingConditionExpression;
+import com.consol.citrus.context.TestContext;
+import com.consol.citrus.dsl.design.DefaultTestDesigner;
+import com.consol.citrus.dsl.design.TestDesigner;
+import com.consol.citrus.message.MessageType;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetupTest;
+import org.apache.camel.Route;
+import org.apache.camel.ServiceStatus;
+import org.apache.camel.model.ModelCamelContext;
+import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
+import org.junit.*;
+import org.springframework.core.io.ClassPathResource;
+
+import java.util.List;
 
 public class EmailListenerTest extends CamelBlueprintTestSupport {
-
-	private static final Logger LOG = LoggerFactory.getLogger(EmailListenerTest.class);
-	
-	protected static BrokerService broker;
-
-	protected static final String ATTACHMENT_DIR_STRING = "./src/test/resources/test-data/";
-	protected static final File ATTACHMENT_FILE = new File(ATTACHMENT_DIR_STRING + "emailPollRecords-basicTest.txt");
 
 	private static final String USER_NAME = "accountone";
 	private static final String USER_PASSWORD = "accountone";
 	private static final String EMAIL_USER_ADDRESS = "accountone@localhost";
-	private static final String EMAIL_TO = "accountone@127.0.0.1";
-	private static final String EMAIL_SUBJECT = "Test E-Mail";
 
 	private GreenMail mailServer;
 
-	private GreenMailUser user;
+	private Citrus citrus;
+	private TestDesigner designer;
 
 	@Override
 	@Before
 	public void setUp() throws Exception {
-		
-		// Embed a JMS Broker for testing
-		broker = new BrokerService();
-		final TransportConnector connector = new TransportConnector();
-		connector.setUri(new URI("tcp://localhost:61615"));
-		broker.setBrokerName("activemq");
-		broker.addConnector(connector);
-		broker.setPersistent(false);
-		broker.start();
-
 		// GreenMail sets Test Server up on Port 3110
-		mailServer = new GreenMail(ServerSetupTest.POP3);
+		mailServer = new GreenMail(ServerSetupTest.SMTP_POP3);
 		mailServer.start();
 
-		user = mailServer.setUser(EMAIL_USER_ADDRESS, USER_NAME, USER_PASSWORD);
+		mailServer.setUser(EMAIL_USER_ADDRESS, USER_NAME, USER_PASSWORD);
+
+		citrus = Citrus.newInstance();
+		designer = new DefaultTestDesigner(citrus.getApplicationContext(), citrus.createTestContext());
 
 		// Creates the Blueprint Context
 		super.setUp();
@@ -79,10 +49,6 @@ public class EmailListenerTest extends CamelBlueprintTestSupport {
 	@After
 	public void tearDown() throws Exception {
 		mailServer.stop();
-		
-		broker.stop();
-		broker = null;
-		
 		super.tearDown();
 	}
 
@@ -97,76 +63,41 @@ public class EmailListenerTest extends CamelBlueprintTestSupport {
 				"org.jboss.fuse.service.polling.emaillistener" };
 	}
 
-	@Override
-	protected RouteBuilder createRouteBuilder() {
-		return new RouteBuilder() {
-
-			public void configure() {
-				from("activemq:org.jboss.fuse.service.polling.processor.queue").id("emaillistenunittest")
-						.to("file:data/out?fileName=record-${date:now:yyyyMMdd-hhmmssSSSS}").to("mock:result");
-			}
-
-		};
-	}
-
 	@Test
 	public void testEmailRoute() throws Exception {
-
-		LOG.info("testEmailRoute::start");
-
-		// wait 1 second for Listener Route to start
-		Thread.sleep(1000);
-
-		ServiceStatus routeStatus = this.context.getRouteStatus("poll.email.receive");
+		designer.echo("testEmailRoute::start");
 
 		// Show routes for information
 		List<Route> routes = this.context().getRoutes();
 		for (Route r : routes) {
-			LOG.info("+Route: " + r.getId());
+			designer.echo("+Route: " + r.getId());
 		}
 
-		if (null != routeStatus) {
+		designer.camel()
+				.context((ModelCamelContext) this.context())
+				.controlBus()
+				.route("poll.email.receive", "status")
+				.result(ServiceStatus.Started);
 
-			assertTrue("Route was not created", routeStatus.isStarted());
+		designer.echo("Delivering Email w/ Attachment");
 
-			MimeMessage message = new MimeMessage((Session) null);
-			message.setFrom(new InternetAddress(EMAIL_TO));
-			message.addRecipient(Message.RecipientType.TO, new InternetAddress(EMAIL_USER_ADDRESS));
-			message.setSubject(EMAIL_SUBJECT);
-			message.setSentDate(Calendar.getInstance().getTime());
+		designer.send("mailClient")
+				.payload(new ClassPathResource("test-data/send-mail.xml"));
 
-			MimeBodyPart bodyPart = new MimeBodyPart();
-			bodyPart.setText("This is the email body text");
+		designer.iterate().condition(new IteratingConditionExpression() {
+			@Override
+			public boolean evaluate(int i, TestContext context) {
+				return i <= 5;
+			}
+		}).actions(
+			designer.receive("servicePollingJmsEndpoint")
+					.messageType(MessageType.XML)
+					.payload("citrus:readFile('test-data/flightSegmentRecord_${i}.xml')")
+		);
 
-			MimeBodyPart attachmentPart = new MimeBodyPart();
-			DataSource source = new FileDataSource(ATTACHMENT_FILE);
-			attachmentPart.setDataHandler(new DataHandler(source));
-			attachmentPart.setFileName("emailPollRecords-basicTest.txt");
+		designer.echo("testDynamicEmailRoute::end");
 
-			Multipart multipart = new MimeMultipart();
-			multipart.addBodyPart(bodyPart);
-			multipart.addBodyPart(attachmentPart);
-
-			message.setContent(multipart);
-
-			LOG.info("Delivering Email w/ Attachment");
-
-			user.deliver(message);
-
-			// wait 2 seconds for route to start and process
-			Thread.sleep(2000);
-
-			getMockEndpoint("mock:result").expectedMinimumMessageCount(1);
-
-			// assert expectations
-			assertMockEndpointsSatisfied();
-
-		} else {
-			assertFalse("RouteStatus is null", true);
-		}
-
-		LOG.info("testDynamicEmailRoute::end");
-
+		citrus.run(designer.getTestCase());
 	}
 
 }

--- a/service.polling.emaillistener/src/test/resources/citrus-context.xml
+++ b/service.polling.emaillistener/src/test/resources/citrus-context.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:amq="http://activemq.apache.org/schema/core"
+       xmlns:citrus="http://www.citrusframework.org/schema/config"
+       xmlns:citrus-jms="http://www.citrusframework.org/schema/jms/config"
+       xmlns:citrus-mail="http://www.citrusframework.org/schema/mail/config"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+                         http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd
+                         http://www.citrusframework.org/schema/config http://www.citrusframework.org/schema/config/citrus-config.xsd
+                         http://www.citrusframework.org/schema/jms/config http://www.citrusframework.org/schema/jms/config/citrus-jms-config.xsd
+                         http://www.citrusframework.org/schema/mail/config http://www.citrusframework.org/schema/mail/config/citrus-mail-config.xsd">
+
+  <!-- Embedded ActiveMQ JMS broker -->
+  <amq:broker useJmx="false" persistent="false">
+    <amq:transportConnectors>
+      <amq:transportConnector uri="tcp://localhost:61615" />
+    </amq:transportConnectors>
+  </amq:broker>
+
+  <bean id="connectionFactory" class="org.apache.activemq.ActiveMQConnectionFactory">
+    <property name="brokerURL" value="tcp://localhost:61615" />
+    <property name="watchTopicAdvisories" value="false"/>
+  </bean>
+
+  <!-- Mail client -->
+  <citrus-mail:client id="mailClient"
+                      host="localhost"
+                      port="3025"
+                      username="accountone"
+                      password="accountone"/>
+
+  <!-- JMS service polling endpoint -->
+  <citrus-jms:endpoint id="servicePollingJmsEndpoint"
+                       destination-name="org.jboss.fuse.service.polling.processor.queue"/>
+
+</beans>

--- a/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_1.xml
+++ b/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_1.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<flightSegmentRecord>
+  <airline>American</airline>
+  <airlineAccountId>ABC123</airlineAccountId>
+  <airlineStatus>Executive Platinum</airlineStatus>
+  <arrivalCode>ORD</arrivalCode>
+  <arrivalDate>01/01/2016</arrivalDate>
+  <arrivalTime>10:00</arrivalTime>
+  <associatedMonth>JAN</associatedMonth>
+  <departureCode>DCA</departureCode>
+  <departureDate>01/01/2016</departureDate>
+  <departureTime>08:00</departureTime>
+  <fareCode>Q</fareCode>
+  <firstName>Joseph</firstName>
+  <flightNumber>1234</flightNumber>
+  <lastName>Butler</lastName>
+  <personUUID></personUUID>
+  <recordLocator>LOC001</recordLocator>
+  <ticketNumber>012344494</ticketNumber>
+  <transactionId>1000</transactionId>
+</flightSegmentRecord>

--- a/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_2.xml
+++ b/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<flightSegmentRecord>
+  <airline>American</airline>
+  <airlineAccountId>ABC123</airlineAccountId>
+  <airlineStatus>Executive Platinum</airlineStatus>
+  <arrivalCode>LAX</arrivalCode>
+  <arrivalDate>01/01/2016</arrivalDate>
+  <arrivalTime>15:00</arrivalTime>
+  <associatedMonth>JAN</associatedMonth>
+  <departureCode>ORD</departureCode>
+  <departureDate>01/01/2016</departureDate>
+  <departureTime>12:00</departureTime>
+  <fareCode>Q</fareCode>
+  <firstName>Joseph</firstName>
+  <flightNumber>5133</flightNumber>
+  <lastName>Butler</lastName>
+  <personUUID></personUUID>
+  <recordLocator>LOC001</recordLocator>
+  <ticketNumber>012344495</ticketNumber>
+  <transactionId>1001</transactionId>
+</flightSegmentRecord>

--- a/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_3.xml
+++ b/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_3.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<flightSegmentRecord>
+  <airline>American</airline>
+  <airlineAccountId>ABC123</airlineAccountId>
+  <airlineStatus>Executive Platinum</airlineStatus>
+  <arrivalCode>DFW</arrivalCode>
+  <arrivalDate>01/03/2016</arrivalDate>
+  <arrivalTime>11:00</arrivalTime>
+  <associatedMonth>JAN</associatedMonth>
+  <departureCode>LAX</departureCode>
+  <departureDate>01/03/2016</departureDate>
+  <departureTime>08:00</departureTime>
+  <fareCode>A</fareCode>
+  <firstName>Joseph</firstName>
+  <flightNumber>6345</flightNumber>
+  <lastName>Butler</lastName>
+  <personUUID></personUUID>
+  <recordLocator>LOC004</recordLocator>
+  <ticketNumber>012344496</ticketNumber>
+  <transactionId>1002</transactionId>
+</flightSegmentRecord>

--- a/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_4.xml
+++ b/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_4.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<flightSegmentRecord>
+  <airline>American</airline>
+  <airlineAccountId>ABC123</airlineAccountId>
+  <airlineStatus>Executive Platinum</airlineStatus>
+  <arrivalCode>FLL</arrivalCode>
+  <arrivalDate>01/03/2016</arrivalDate>
+  <arrivalTime>18:00</arrivalTime>
+  <associatedMonth>JAN</associatedMonth>
+  <departureCode>DFW</departureCode>
+  <departureDate>01/03/2016</departureDate>
+  <departureTime>08:00</departureTime>
+  <fareCode>Q</fareCode>
+  <firstName>Joseph</firstName>
+  <flightNumber>8123</flightNumber>
+  <lastName>Butler</lastName>
+  <personUUID></personUUID>
+  <recordLocator>LOC004</recordLocator>
+  <ticketNumber>012344497</ticketNumber>
+  <transactionId>1003</transactionId>
+</flightSegmentRecord>

--- a/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_5.xml
+++ b/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_5.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<flightSegmentRecord>
+  <airline>American</airline>
+  <airlineAccountId>ABC123</airlineAccountId>
+  <airlineStatus>Executive Platinum</airlineStatus>
+  <arrivalCode>CLT</arrivalCode>
+  <arrivalDate>01/10/2016</arrivalDate>
+  <arrivalTime>10:00</arrivalTime>
+  <associatedMonth>JAN</associatedMonth>
+  <departureCode>FLL</departureCode>
+  <departureDate>01/10/2016</departureDate>
+  <departureTime>08:00</departureTime>
+  <fareCode>D</fareCode>
+  <firstName>Joseph</firstName>
+  <flightNumber>4382</flightNumber>
+  <lastName>Butler</lastName>
+  <personUUID></personUUID>
+  <recordLocator>LOC006</recordLocator>
+  <ticketNumber>012344498</ticketNumber>
+  <transactionId>1004</transactionId>
+</flightSegmentRecord>

--- a/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_6.xml
+++ b/service.polling.emaillistener/src/test/resources/test-data/flightSegmentRecord_6.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<flightSegmentRecord>
+  <airline>American</airline>
+  <airlineAccountId>ABC123</airlineAccountId>
+  <airlineStatus>Executive Platinum</airlineStatus>
+  <arrivalCode>DCA</arrivalCode>
+  <arrivalDate>01/10/2016</arrivalDate>
+  <arrivalTime>14:30</arrivalTime>
+  <associatedMonth>JAN</associatedMonth>
+  <departureCode>CLT</departureCode>
+  <departureDate>01/10/2016</departureDate>
+  <departureTime>13:00</departureTime>
+  <fareCode>Q</fareCode>
+  <firstName>Joseph</firstName>
+  <flightNumber>2789</flightNumber>
+  <lastName>Butler</lastName>
+  <personUUID></personUUID>
+  <recordLocator>LOC006</recordLocator>
+  <ticketNumber>012344499</ticketNumber>
+  <transactionId>1005</transactionId>
+</flightSegmentRecord>

--- a/service.polling.emaillistener/src/test/resources/test-data/send-mail.xml
+++ b/service.polling.emaillistener/src/test/resources/test-data/send-mail.xml
@@ -1,0 +1,18 @@
+<mail-message xmlns="http://www.citrusframework.org/schema/mail/message">
+  <from>citrus@localhost</from>
+  <to>accountone@localhost</to>
+  <cc></cc>
+  <bcc></bcc>
+  <subject>Test E-Mail</subject>
+  <body>
+    <contentType>text/plain; charset=utf-8</contentType>
+    <content>This is the email body text</content>
+    <attachments>
+      <attachment>
+        <contentType>text/plain; charset=utf-8</contentType>
+        <content>citrus:readFile('classpath:test-data/emailPollRecords-basicTest.txt')</content>
+        <fileName>emailPollRecords-basicTest.txt</fileName>
+      </attachment>
+    </attachments>
+  </body>
+</mail-message>


### PR DESCRIPTION
I promised to send you a PR for adding Citrus to the project. I have started to do so for email listener module.

I had some trouble with OSGI and Spring framework version. Citrus works with a newer version of Spring and I did not really know how to add this new version other than overwriting the version in the Maven POM. As I am not very familiar with OSGI I do not know if this is the best way, please review. 

Good news: the test is green working with Citrus! Now Citrus is used to send the mail and Citrus receives all records on JMS queue validating the XML message content.

Please let me know how you feel about that!
